### PR TITLE
Header Readers for more flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ SlackGlossaryBot supports two file formats for providing glossary data: CSV and 
 
 **CSV Format**
 
-Glossary data in CSV format should be organized with two columns: "Term" and "Description". Each row represents a unique entry in the glossary, with the term and its corresponding description listed in separate columns.
+Glossary data in CSV format should be organized with two columns.  The first column should contain the acronyms or terms and the second column should contain the definition. Each row represents a unique entry in the glossary, with the term and its corresponding description listed in separate columns.
 
 Example:
 ```
@@ -99,8 +99,8 @@ UNESCO,United Nations Educational, Scientific and Cultural Organization
 **JSON Format**
 
 In the JSON format, glossary entries can be represented in different ways depending on whether duplicates are aggregated or not.
-For unique entries for each acronym, each object in the JSON array should contain the keys "Term" and "Description", representing a single entry in the glossary.
-If the JSON file is preprocessed (i.e., `preprocess: True`), the format is simplified. The keys represent the acronyms, and the values can be either strings or lists, where multiple descriptions are aggregated into lists for duplicate acronyms.
+
+In the standard representation, each glossary entry is encapsulated within an object in the JSON array. Each object contains keys representing the term and its corresponding definition or description. For example:
 
 Example (Unique Entries):
 
@@ -122,6 +122,8 @@ Example (Unique Entries):
 ]
 ```
 
+If the JSON file is preprocessed (i.e., `preprocess: True`), the format is simplified. The keys represent the acronyms, and the values can be either strings or lists, where multiple descriptions are aggregated into lists for duplicate acronyms.
+
 Example (Preprocessed JSON):
 ```
 {
@@ -135,6 +137,7 @@ Example (Preprocessed JSON):
   "WHO": "World Health Organization"
 }
 ```
+Here, the key-value pairs directly reflect the terms and their definitions, allowing for a more streamlined representation of the glossary entries.
 
 ## Running the App
 

--- a/SlackGlossaryBot/glossary/glossary.py
+++ b/SlackGlossaryBot/glossary/glossary.py
@@ -170,10 +170,9 @@ def load_glossary(config):
     elif glossary_type.lower() == "csv":
         # Load glossary from CSV file
         glossary_df = pd.read_csv(glossary_file)
-        # Convert the 'Term' column to lowercase
-        glossary_df["Term"] = glossary_df["Term"].str.upper()
-        # Group the DataFrame by 'Term' (acronym) and aggregate the descriptions into a list
-        glossary_grouped = glossary_df.groupby("Term")["Description"].agg(list)
+        headers = glossary_df.columns.tolist()
+        # Group the DataFrame by 'header[0]' (acronym) and aggregate the descriptions 'header[1]' into a list
+        glossary_grouped = glossary_df.groupby(headers[0])[headers[1]].agg(list)
         # Convert the grouped DataFrame to a dictionary
         glossary = glossary_grouped.to_dict()
 

--- a/SlackGlossaryBot/glossary/glossary.py
+++ b/SlackGlossaryBot/glossary/glossary.py
@@ -139,8 +139,9 @@ def load_glossary(config):
     elif glossary_type.lower() == "csv":
         # Load glossary from CSV file
         glossary_df = pd.read_csv(glossary_file)
-        # Group the DataFrame by 'Term' (acronym) and aggregate the descriptions into a list
-        glossary_grouped = glossary_df.groupby("Term")["Description"].agg(list)
+        headers = glossary_df.columns.tolist()
+        # Group the DataFrame by 'header[0]' (acronym) and aggregate the descriptions 'header[1]' into a list
+        glossary_grouped = glossary_df.groupby(headers[0])[headers[1]].agg(list)
         # Convert the grouped DataFrame to a dictionary
         glossary = glossary_grouped.to_dict()
     else:

--- a/SlackGlossaryBot/glossary/glossary.py
+++ b/SlackGlossaryBot/glossary/glossary.py
@@ -110,6 +110,30 @@ def load_config(file_path):
         raise ValueError("Invalid YAML format in config file.")
 
 
+def read_json_header(glossary_data):
+    """Read JSON Header.
+
+    Read the header of a JSON file.
+
+    Paramters
+    ---------
+    glossary_data: list
+        List of dictionaries representing data from a JSON file.
+
+    Returns
+    -------
+    headers: list
+        List of strings representing the header keys.
+    """
+
+    if glossary_data:  # Check if the JSON file is not empty
+        first_row = glossary_data[0]
+        headers = list(first_row.keys())
+    else:
+        headers = []  # If the JSON file is empty or has no data
+    return headers
+
+
 def preprocess_glossary(glossary_data):
     """
     Preprocess the glossary data by concatenating duplicate definitions.
@@ -125,9 +149,10 @@ def preprocess_glossary(glossary_data):
         Preprocessed glossary with concatenated definitions.
     """
     glossary = {}
+    header = read_json_header(glossary_data)
     for item in glossary_data:
-        acronym = item["Term"].lower()
-        definition = item["Description"]
+        acronym = item[header[0]].lower()
+        definition = item[header[1]]
         if acronym in glossary:
             glossary[acronym].append(definition)
         else:
@@ -183,6 +208,7 @@ def load_glossary(config):
 
 def to_camel_case(entry):
     return " ".join(x.capitalize() for x in entry.split())
+
 
 def retrieve_definitions(args, glossary, language_phrases="english", similarity=0.8):
     """

--- a/config/config_csv.yml
+++ b/config/config_csv.yml
@@ -1,6 +1,5 @@
 language: english
-  # /opt/SlackGlossaryBot/
-path: /opt/SlackGlossaryBot/SlackGlossaryBot/glossary/glossarydefs.csv
+path: SlackGlossaryBot/glossary/glossarydefs.csv
 file_type: csv
 # Print similar keywords, given a match fraction.
 similarity: 0.8

--- a/config/config_csv.yml
+++ b/config/config_csv.yml
@@ -1,5 +1,4 @@
 language: english
-  # /opt/SlackGlossaryBot/
 path: SlackGlossaryBot/glossary/glossarydefs.csv
 file_type: csv
 # Print similar keywords, given a match fraction.

--- a/config/config_es.yml
+++ b/config/config_es.yml
@@ -1,6 +1,5 @@
 language: spanish
-#/opt/SlackGlossaryBot/
-path: /opt/SlackGlossaryBot/SlackGlossaryBot/glossary/corrected_glossarydefs_es.csv
+path: /Users/jenniferpollack/Projects/lsst-texmf/etc/glossarydefs_es.csv
 file_type: csv
 # Print similar keywords, given a match fraction.
 similarity: 0.8


### PR DESCRIPTION
Added Header readers for CSV and JSON (preprocess:False) file formats that allows the user flexibility in the header names.  The only requirement is the order. Column 1 must contain terms and column 2 the definition/translation/etc.
Updated README.